### PR TITLE
#3 provide mappers to map common HTTP errors

### DIFF
--- a/deployment/src/main/java/solutions/cloudstark/quarkus/problem/deployment/ProblemProcessor.java
+++ b/deployment/src/main/java/solutions/cloudstark/quarkus/problem/deployment/ProblemProcessor.java
@@ -16,17 +16,20 @@
 
 package solutions.cloudstark.quarkus.problem.deployment;
 
+import java.util.Arrays;
+import org.zalando.problem.DefaultProblem;
+import org.zalando.problem.violations.ConstraintViolationProblem;
+import org.zalando.problem.violations.Violation;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.jsonb.spi.JsonbSerializerBuildItem;
 import io.quarkus.resteasy.common.spi.ResteasyJaxrsProviderBuildItem;
-import java.util.Arrays;
-import org.zalando.problem.DefaultProblem;
-import org.zalando.problem.violations.ConstraintViolationProblem;
-import org.zalando.problem.violations.Violation;
+import solutions.cloudstark.quarkus.problem.runtime.ForbiddenExceptionMapper;
+import solutions.cloudstark.quarkus.problem.runtime.NotFoundExceptionMapper;
 import solutions.cloudstark.quarkus.problem.runtime.RestExceptionMapper;
+import solutions.cloudstark.quarkus.problem.runtime.UnAuthorizedExceptionMapper;
 import solutions.cloudstark.quarkus.problem.runtime.jsonb.ConstraintViolationProblemSerializer;
 import solutions.cloudstark.quarkus.problem.runtime.jsonb.DefaultProblemSerializer;
 import solutions.cloudstark.quarkus.problem.runtime.jsonb.ViolationSerializer;
@@ -60,6 +63,10 @@ public class ProblemProcessor {
 
   @BuildStep
   void registerJaxrsProviders(final BuildProducer<ResteasyJaxrsProviderBuildItem> providers) {
+    providers.produce(new ResteasyJaxrsProviderBuildItem(ForbiddenExceptionMapper.class.getName()));
+    providers.produce(new ResteasyJaxrsProviderBuildItem(NotFoundExceptionMapper.class.getName()));
+    providers.produce(
+        new ResteasyJaxrsProviderBuildItem(UnAuthorizedExceptionMapper.class.getName()));
     providers.produce(new ResteasyJaxrsProviderBuildItem(RestExceptionMapper.class.getName()));
   }
 }

--- a/runtime/src/main/java/solutions/cloudstark/quarkus/problem/runtime/ForbiddenExceptionMapper.java
+++ b/runtime/src/main/java/solutions/cloudstark/quarkus/problem/runtime/ForbiddenExceptionMapper.java
@@ -1,0 +1,52 @@
+/*
+ *    Copyright 2020 SMB GmbH
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package solutions.cloudstark.quarkus.problem.runtime;
+
+import java.net.URI;
+import javax.annotation.Priority;
+import javax.ws.rs.Priorities;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+import org.zalando.problem.Problem;
+import org.zalando.problem.Status;
+import org.zalando.problem.ThrowableProblem;
+import io.quarkus.security.ForbiddenException;
+
+@Provider
+@Priority(Priorities.USER)
+public class ForbiddenExceptionMapper implements ExceptionMapper<ForbiddenException> {
+
+  @Context private UriInfo uriInfo;
+
+  @Override
+  public Response toResponse(ForbiddenException exception) {
+    ThrowableProblem throwableProblem =
+        Problem.builder()
+            .withStatus(Status.FORBIDDEN)
+            .withTitle(exception.getMessage())
+            .withDetail(exception.toString())
+            .withInstance(URI.create(uriInfo.getPath()))
+            .build();
+    return Response.status(throwableProblem.getStatus().getStatusCode())
+        .type(MediaType.APPLICATION_PROBLEM_JSON)
+        .entity(throwableProblem)
+        .build();
+  }
+}

--- a/runtime/src/main/java/solutions/cloudstark/quarkus/problem/runtime/NotFoundExceptionMapper.java
+++ b/runtime/src/main/java/solutions/cloudstark/quarkus/problem/runtime/NotFoundExceptionMapper.java
@@ -1,0 +1,37 @@
+package solutions.cloudstark.quarkus.problem.runtime;
+
+import java.net.URI;
+import javax.annotation.Priority;
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.Priorities;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+import org.zalando.problem.Problem;
+import org.zalando.problem.Status;
+import org.zalando.problem.ThrowableProblem;
+
+@Provider
+@Priority(Priorities.USER)
+public class NotFoundExceptionMapper implements ExceptionMapper<NotFoundException> {
+
+  @Context
+  private UriInfo uriInfo;
+
+  @Override
+  public Response toResponse(NotFoundException exception) {
+    ThrowableProblem throwableProblem =
+        Problem.builder()
+            .withStatus(Status.NOT_FOUND)
+            .withTitle(exception.getMessage())
+            .withDetail(exception.toString())
+            .withInstance(URI.create(uriInfo.getPath()))
+            .build();
+    return Response.status(throwableProblem.getStatus().getStatusCode())
+        .type(MediaType.APPLICATION_PROBLEM_JSON)
+        .entity(throwableProblem)
+        .build();
+  }
+}

--- a/runtime/src/main/java/solutions/cloudstark/quarkus/problem/runtime/NotFoundExceptionMapper.java
+++ b/runtime/src/main/java/solutions/cloudstark/quarkus/problem/runtime/NotFoundExceptionMapper.java
@@ -1,3 +1,19 @@
+/*
+ *    Copyright 2020 SMB GmbH
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
 package solutions.cloudstark.quarkus.problem.runtime;
 
 import java.net.URI;

--- a/runtime/src/main/java/solutions/cloudstark/quarkus/problem/runtime/UnAuthorizedExceptionMapper.java
+++ b/runtime/src/main/java/solutions/cloudstark/quarkus/problem/runtime/UnAuthorizedExceptionMapper.java
@@ -1,0 +1,53 @@
+/*
+ *    Copyright 2020 SMB GmbH
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package solutions.cloudstark.quarkus.problem.runtime;
+
+import java.net.URI;
+import javax.annotation.Priority;
+import javax.ws.rs.Priorities;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+import org.zalando.problem.Problem;
+import org.zalando.problem.Status;
+import org.zalando.problem.ThrowableProblem;
+import io.quarkus.security.UnauthorizedException;
+
+@Provider
+@Priority(Priorities.USER)
+public class UnAuthorizedExceptionMapper implements ExceptionMapper<UnauthorizedException> {
+
+  @Context
+  private UriInfo uriInfo;
+
+  @Override
+  public Response toResponse(UnauthorizedException exception) {
+    ThrowableProblem throwableProblem =
+      Problem.builder()
+        .withStatus(Status.UNAUTHORIZED)
+        .withTitle(exception.getMessage())
+        .withDetail(exception.toString())
+        .withInstance(URI.create(uriInfo.getPath()))
+        .build();
+    return Response.status(throwableProblem.getStatus().getStatusCode())
+      .type(MediaType.APPLICATION_PROBLEM_JSON)
+      .entity(throwableProblem)
+      .build();
+  }
+}


### PR DESCRIPTION
This PR adds exception mappers for common HTTP errors. The mappers
are registered with higher priority then the default mappers provided
by Quarkus. 